### PR TITLE
Larsg suppress sync actions in originating editor

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,11 +21,11 @@
   "dependencies": {
     "@findr/mui": "^1.0.0-beta.17",
     "@findr/react": "^1.0.0-beta.3",
+    "@findr/text": "^1.0.7-beta.4",
     "@gwdevs/extensible-rcl": "^1.0.1",
     "@xelah/type-perf-html": "^1.0.2",
     "epitelete-html": "^0.2.20-beta.7",
     "pagedjs": "^0.4.1",
-    "@findr/text": "^1.0.7-beta.4",
     "proskomma-core": "^0.10.1",
     "react-uuid": "^2.0.0"
   },

--- a/packages/core/src/components/Editor.jsx
+++ b/packages/core/src/components/Editor.jsx
@@ -24,6 +24,8 @@ import GraftPopup from "./GraftPopup"
 import FindReplace from './FindReplace';
 import { Highlighted } from '../findr/highlights/components/Highlighted';
 
+// import { getDiff } from 'json-difference'
+
 export default function Editor( props) {
   const { 
     onSave, epiteleteHtml, 
@@ -196,7 +198,11 @@ export default function Editor( props) {
   const onHtmlPerf = useDeepCompareCallback(( _htmlPerf, { sequenceId }) => {
     setBlockIsEdited(false)
     const perfChanged = !isEqual(htmlPerf, _htmlPerf)
-    if (perfChanged) setHtmlPerf(_htmlPerf)
+    if (perfChanged) {
+      console.log("perfChanged")
+      // console.log(getDiff(_htmlPerf,htmlPerf))
+      setHtmlPerf(_htmlPerf)
+    }
 
     if (verbose) console.log('onhtmlperf', perfChanged)
     const saveNow = async () => {
@@ -271,7 +277,7 @@ export default function Editor( props) {
     refEditors.length > 0 && Array.prototype.filter.call(refEditors, (refEditor) => {
       const editorInView = refEditor.querySelector(`#ch-${chapterNumber}`)
       if (editorInView) {
-        // editorInView.scrollIntoView()
+        editorInView.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
         // editorInView.classList.add('scroll-mt-10')
       }
     })
@@ -287,13 +293,13 @@ export default function Editor( props) {
 
       const existingVerse = editorRef.current.querySelector(`span.mark.verses.highlight-verse`)
       if ( existingVerse ) {
-        existingVerse.classList.remove('highlight-verse')
+        // existingVerse.classList.remove('highlight-verse')
       }
 
       const verseElem = editorRef.current.querySelector(`span.mark.verses[data-atts-number='${verse}']`)
       if ((uniqueId!==syncSrcId) && (verseElem)) {
-        verseElem.classList.add('highlight-verse')
-        verseElem.scrollIntoView({ block: "center"})
+        // verseElem.classList.add('highlight-verse')
+        verseElem.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -302,6 +308,7 @@ export default function Editor( props) {
   const onIntersection = (entries) => {
     for (const entry of entries) {
       if (entry.isIntersecting) {
+        console.log("entry.isIntersecting")
         console.log({ entry })
         setChapterNumber && setChapterNumber(entry.target.dataset.attsNumber)
         (!scrollLock) && scrollReference(entry.target.dataset.attsNumber) 

--- a/packages/core/src/components/Editor.md
+++ b/packages/core/src/components/Editor.md
@@ -1,189 +1,5 @@
 # Editor demo 1
 
-The Editor expects input of an EpiteleteHtml object.
-
-```js
-import { useState, useEffect } from 'react'
-
-import EpiteleteHtml from "epitelete-html"
-
-import { usfmText } from '../data/Acts.1.usfm.js'
-import { usfm2perf } from '../helpers/usfm2perf'
-
-function Component () {
-  const verbose = true
-  const docSetId = "Xxx/en_act" // just dummy values
-  const [ready,setReady] = useState(false)
-  const [epiteleteHtml, setEpiteleteHtml] = useState(
-    new EpiteleteHtml(
-      { proskomma: undefined, docSetId, options: { historySize: 100 } }
-    )
-  )
-  
-  const onSave = (bookCode,usfmText) => {
-    console.log(`save button clicked: ${bookCode}, ${usfmText}`) 
-  }
-  const onReferenceSelected = (reference) => {
-    console.log(`onReferenceSelected: ${reference}`)
-  }
-  
-  useEffect(() => {
-    async function loadUsfm() {
-      const tempPerf = usfm2perf(usfmText)
-      await epiteleteHtml.sideloadPerf('ACT', tempPerf)
-      setReady(true)
-    }
-    if (epiteleteHtml) loadUsfm()
-  }, [epiteleteHtml])
- 
-  const editorProps = {
-    epiteleteHtml,
-    bookId: 'act',
-    onSave,
-    onReferenceSelected,
-    bcvSyncRef: {
-      bookId: 'act',
-      chapter: 1,
-      verse: 4,
-    },
-    verbose
-  }
- 
-  return (
-    <>
-    <div key="1">
-      { ready ? <Editor key="1" {...editorProps} /> : 'Loading...' }
-    </div>
-    </>
-  )
-}  
-
-<Component key="1" />
-
-```
-
-## Editor demo 2
-
-The demo demonstrates using Epitelete in standalone mode (no Proskomma) including some added toolbar buttons (extended through "onRenderToolbar")
-Here is the function for sideloading:
-
-```txt
-    /**
-     * Loads given perf into memory
-     * @param {string} bookCode
-     * @param {perfDocument} perfDocument - PERF document
-     * @return {Promise<perfDocument>} same sideloaded PERF document
-     */
-    async sideloadPerf(bookCode, perfDocument, options = {}) {
-```
-
-```js
-import { useState, useEffect } from 'react'
-
-import __htmlPerf from '../data/tit.en.ult.perf.json'
-import EpiteleteHtml from "epitelete-html"
-  
-import { Button } from '@mui/material'
-import { MdUpdate } from 'react-icons/md'
-import { FiShare } from 'react-icons/fi'
-
-function Component () {
-  const proskomma = null
-  const docSetId = 'unfoldingWord_ult'
-  const [ready, setReady] = useState(false)
-  const [ep, setEp] = useState(new EpiteleteHtml({ proskomma, docSetId, options: { historySize: 100 } }))
-  const verbose = true
-
-  const onSave = async (bookCode,usfmText) => {
-    console.log("save button clicked")
-    console.log("USFM:",usfmText)
-    console.log("Trying getDocument() method")
-    const perfJson = await ep.getDocument(bookCode)
-    console.log("PERF:",JSON.stringify(perfJson, null, 4))
-  }
-
-  useEffect(
-    () => {
-      async function loadPerf() {
-          console.log("Start side load of Titus")
-          const data = await ep.sideloadPerf('TIT', __htmlPerf)
-          console.log("End side load of Titus", data)
-          console.log("Books loaded:", ep.localBookCodes())
-          setReady(true)
-      }
-      if ( ep && !ready ) loadPerf()
-    }, [ep, ready]
-  )
-
-  const needToMergeFromMaster = true
-  const mergeFromMasterHasConflicts = false
-  const mergeToMasterHasConflicts = true
-
-  // eslint-disable-next-line no-nested-ternary
-  const mergeFromMasterTitle = mergeFromMasterHasConflicts
-    ? 'Merge Conflicts for update from master'
-    : needToMergeFromMaster
-      ? 'Update from master'
-      : 'No merge conflicts for update with master'
-  // eslint-disable-next-line no-nested-ternary
-  const mergeFromMasterColor = mergeFromMasterHasConflicts
-    ? 'red'
-    : needToMergeFromMaster
-      ? 'orange'
-      : 'lightgray'
-  const mergeToMasterTitle = mergeToMasterHasConflicts
-    ? 'Merge Conflicts for share with master'
-    : 'No merge conflicts for share with master'
-  const mergeToMasterColor = mergeToMasterHasConflicts ? 'red' : 'black'
-
-  const onRenderToolbar = ({ items }) => [
-    ...items,
-    <Button
-      key="update-from-master"
-      value="update-from-master"
-      onClick={() => {}}
-      title={mergeFromMasterTitle}
-      aria-label={mergeFromMasterTitle}
-      style={{ cursor: 'pointer' }}
-    >
-      <MdUpdate id="update-from-master-icon" color={mergeFromMasterColor} />
-    </Button>,
-    <Button
-      key="share-to-master"
-      value="share-to-master"
-      onClick={() => {}}
-      title={mergeToMasterTitle}
-      aria-label={mergeToMasterTitle}
-      style={{ cursor: 'pointer' }}
-    >
-      <FiShare id="share-to-master-icon" color={mergeToMasterColor} />
-    </Button>,
-  ]
-
-  const editorProps = {
-    epiteleteHtml: ep,
-    bookId: 'TIT',
-    editable: true,
-    onSave,
-    onRenderToolbar,
-    verbose
-  }
-  
-  return (
-    <>
-    <div key="1">
-      { ready ? <Editor key="1" {...editorProps} /> : 'Loading...'}
-    </div>
-    </>
-  )
-}  
-
-<Component key="1" />
-
-```
-
-## Editor demo 3
-
 The demo demonstrates using two Editor instances (side by side) including synchronised navigation.
 
 ```js
@@ -332,5 +148,189 @@ function DoubleContainer () {
 }
 
 <DoubleContainer/>
+
+```
+
+## Editor demo 2
+
+The Editor expects input of an EpiteleteHtml object.
+
+```js
+import { useState, useEffect } from 'react'
+
+import EpiteleteHtml from "epitelete-html"
+
+import { usfmText } from '../data/Acts.1.usfm.js'
+import { usfm2perf } from '../helpers/usfm2perf'
+
+function Component () {
+  const verbose = true
+  const docSetId = "Xxx/en_act" // just dummy values
+  const [ready,setReady] = useState(false)
+  const [epiteleteHtml, setEpiteleteHtml] = useState(
+    new EpiteleteHtml(
+      { proskomma: undefined, docSetId, options: { historySize: 100 } }
+    )
+  )
+  
+  const onSave = (bookCode,usfmText) => {
+    console.log(`save button clicked: ${bookCode}, ${usfmText}`) 
+  }
+  const onReferenceSelected = (reference) => {
+    console.log(`onReferenceSelected: ${reference}`)
+  }
+  
+  useEffect(() => {
+    async function loadUsfm() {
+      const tempPerf = usfm2perf(usfmText)
+      await epiteleteHtml.sideloadPerf('ACT', tempPerf)
+      setReady(true)
+    }
+    if (epiteleteHtml) loadUsfm()
+  }, [epiteleteHtml])
+ 
+  const editorProps = {
+    epiteleteHtml,
+    bookId: 'act',
+    onSave,
+    onReferenceSelected,
+    bcvSyncRef: {
+      bookId: 'act',
+      chapter: 1,
+      verse: 4,
+    },
+    verbose
+  }
+ 
+  return (
+    <>
+    <div key="1">
+      { ready ? <Editor key="1" {...editorProps} /> : 'Loading...' }
+    </div>
+    </>
+  )
+}  
+
+<Component key="1" />
+
+```
+
+## Editor demo 3
+
+The demo demonstrates using Epitelete in standalone mode (no Proskomma) including some added toolbar buttons (extended through "onRenderToolbar")
+Here is the function for sideloading:
+
+```txt
+    /**
+     * Loads given perf into memory
+     * @param {string} bookCode
+     * @param {perfDocument} perfDocument - PERF document
+     * @return {Promise<perfDocument>} same sideloaded PERF document
+     */
+    async sideloadPerf(bookCode, perfDocument, options = {}) {
+```
+
+```js
+import { useState, useEffect } from 'react'
+
+import __htmlPerf from '../data/tit.en.ult.perf.json'
+import EpiteleteHtml from "epitelete-html"
+  
+import { Button } from '@mui/material'
+import { MdUpdate } from 'react-icons/md'
+import { FiShare } from 'react-icons/fi'
+
+function Component () {
+  const proskomma = null
+  const docSetId = 'unfoldingWord_ult'
+  const [ready, setReady] = useState(false)
+  const [ep, setEp] = useState(new EpiteleteHtml({ proskomma, docSetId, options: { historySize: 100 } }))
+  const verbose = true
+
+  const onSave = async (bookCode,usfmText) => {
+    console.log("save button clicked")
+    console.log("USFM:",usfmText)
+    console.log("Trying getDocument() method")
+    const perfJson = await ep.getDocument(bookCode)
+    console.log("PERF:",JSON.stringify(perfJson, null, 4))
+  }
+
+  useEffect(
+    () => {
+      async function loadPerf() {
+          console.log("Start side load of Titus")
+          const data = await ep.sideloadPerf('TIT', __htmlPerf)
+          console.log("End side load of Titus", data)
+          console.log("Books loaded:", ep.localBookCodes())
+          setReady(true)
+      }
+      if ( ep && !ready ) loadPerf()
+    }, [ep, ready]
+  )
+
+  const needToMergeFromMaster = true
+  const mergeFromMasterHasConflicts = false
+  const mergeToMasterHasConflicts = true
+
+  // eslint-disable-next-line no-nested-ternary
+  const mergeFromMasterTitle = mergeFromMasterHasConflicts
+    ? 'Merge Conflicts for update from master'
+    : needToMergeFromMaster
+      ? 'Update from master'
+      : 'No merge conflicts for update with master'
+  // eslint-disable-next-line no-nested-ternary
+  const mergeFromMasterColor = mergeFromMasterHasConflicts
+    ? 'red'
+    : needToMergeFromMaster
+      ? 'orange'
+      : 'lightgray'
+  const mergeToMasterTitle = mergeToMasterHasConflicts
+    ? 'Merge Conflicts for share with master'
+    : 'No merge conflicts for share with master'
+  const mergeToMasterColor = mergeToMasterHasConflicts ? 'red' : 'black'
+
+  const onRenderToolbar = ({ items }) => [
+    ...items,
+    <Button
+      key="update-from-master"
+      value="update-from-master"
+      onClick={() => {}}
+      title={mergeFromMasterTitle}
+      aria-label={mergeFromMasterTitle}
+      style={{ cursor: 'pointer' }}
+    >
+      <MdUpdate id="update-from-master-icon" color={mergeFromMasterColor} />
+    </Button>,
+    <Button
+      key="share-to-master"
+      value="share-to-master"
+      onClick={() => {}}
+      title={mergeToMasterTitle}
+      aria-label={mergeToMasterTitle}
+      style={{ cursor: 'pointer' }}
+    >
+      <FiShare id="share-to-master-icon" color={mergeToMasterColor} />
+    </Button>,
+  ]
+
+  const editorProps = {
+    epiteleteHtml: ep,
+    bookId: 'TIT',
+    editable: true,
+    onSave,
+    onRenderToolbar,
+    verbose
+  }
+  
+  return (
+    <>
+    <div key="1">
+      { ready ? <Editor key="1" {...editorProps} /> : 'Loading...'}
+    </div>
+    </>
+  )
+}  
+
+<Component key="1" />
 
 ```

--- a/packages/core/src/components/Editor.md
+++ b/packages/core/src/components/Editor.md
@@ -120,7 +120,7 @@ function DoubleContainer () {
           <Card
             sx={{ display: 'flex', flexDirection: 'column' }}
           >
-            <CardContent sx={{ flexGrow: 1, height: '40vh', overflow: "hidden", overflowY: "auto" }}>
+            <CardContent sx={{ flexGrow: 1, height: '150vh', overflow: "hidden", overflowY: "auto" }}>
               <Component1 
                 bookId={bookId}
                 bcvSyncRef={bcvSyncRef}
@@ -133,7 +133,7 @@ function DoubleContainer () {
           <Card
             sx={{ display: 'flex', flexDirection: 'column' }}
           >
-            <CardContent sx={{ flexGrow: 1, height: '40vh', overflow: "hidden", overflowY: "auto" }}>
+            <CardContent sx={{ flexGrow: 1, height: '150vh', overflow: "hidden", overflowY: "auto" }}>
               <Component2 
                 bookId={bookId}
                 bcvSyncRef={bcvSyncRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3540,7 +3540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nrwl/nx-cloud@latest, @nrwl/nx-cloud@npm:16.1.0":
+"@nrwl/nx-cloud@npm:16.1.0, @nrwl/nx-cloud@npm:latest":
   version: 16.1.0
   resolution: "@nrwl/nx-cloud@npm:16.1.0"
   dependencies:
@@ -11673,7 +11673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.11.0, is-core-module@npm:^2.9.0":
+"is-core-module@npm:^2.11.0, is-core-module@npm:^2.12.0, is-core-module@npm:^2.9.0":
   version: 2.12.1
   resolution: "is-core-module@npm:2.12.1"
   dependencies:
@@ -13956,11 +13956,11 @@ __metadata:
   linkType: hard
 
 "memfs@npm:^3.1.2, memfs@npm:^3.4.3":
-  version: 3.6.0
-  resolution: "memfs@npm:3.6.0"
+  version: 3.5.3
+  resolution: "memfs@npm:3.5.3"
   dependencies:
     fs-monkey: ^1.0.4
-  checksum: 934e79f32aabb10869056815bf369ed63aacb61d13183a3a3826847bbb359d7023fd5b365984ddd73faed463bbb5370ed5cd1e87ecf50ac010c5cac81929ed78
+  checksum: 18dfdeacad7c8047b976a6ccd58bc98ba76e122ad3ca0e50a21837fe2075fc0d9aafc58ab9cf2576c2b6889da1dd2503083f2364191b695273f40969db2ecc44
   languageName: node
   linkType: hard
 
@@ -16407,13 +16407,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.3.5, postcss@npm:^8.4.21, postcss@npm:^8.4.23, postcss@npm:^8.4.4":
-  version: 8.4.25
-  resolution: "postcss@npm:8.4.25"
+  version: 8.4.26
+  resolution: "postcss@npm:8.4.26"
   dependencies:
     nanoid: ^3.3.6
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
-  checksum: 9ed3ab8af43ad5210c28f56f916fd9b8c9f94fbeaebbf645dcf579bc28bdd8056c2a7ecc934668d399b81fedb6128f0c4b299f931e50454964bc911c25a3a0a2
+  checksum: 1cf08ee10d58cbe98f94bf12ac49a5e5ed1588507d333d2642aacc24369ca987274e1f60ff4cbf0081f70d2ab18a5cd3a4a273f188d835b8e7f3ba381b184e57
   languageName: node
   linkType: hard
 
@@ -16996,7 +16996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-react-dom@latest:
+"react-dom@npm:latest":
   version: 18.2.0
   resolution: "react-dom@npm:18.2.0"
   dependencies:
@@ -17345,7 +17345,7 @@ react-dom@latest:
   languageName: node
   linkType: hard
 
-react@latest:
+"react@npm:latest":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
   dependencies:
@@ -17884,15 +17884,15 @@ react@latest:
   linkType: hard
 
 "resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.9.0":
-  version: 1.22.2
-  resolution: "resolve@npm:1.22.2"
+  version: 1.22.3
+  resolution: "resolve@npm:1.22.3"
   dependencies:
-    is-core-module: ^2.11.0
+    is-core-module: ^2.12.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: 7e5df75796ebd429445d102d5824482ee7e567f0070b2b45897b29bb4f613dcbc262e0257b8aeedb3089330ccaea0d6a0464df1a77b2992cf331dcda0f4cb549
+  checksum: fb834b81348428cb545ff1b828a72ea28feb5a97c026a1cf40aa1008352c72811ff4d4e71f2035273dc536dcfcae20c13604ba6283c612d70fa0b6e44519c374
   languageName: node
   linkType: hard
 
@@ -17910,15 +17910,15 @@ react@latest:
   linkType: hard
 
 "resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.9.0#~builtin<compat/resolve>":
-  version: 1.22.2
-  resolution: "resolve@patch:resolve@npm%3A1.22.2#~builtin<compat/resolve>::version=1.22.2&hash=c3c19d"
+  version: 1.22.3
+  resolution: "resolve@patch:resolve@npm%3A1.22.3#~builtin<compat/resolve>::version=1.22.3&hash=c3c19d"
   dependencies:
-    is-core-module: ^2.11.0
+    is-core-module: ^2.12.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: 66cc788f13b8398de18eb4abb3aed90435c84bb8935953feafcf7231ba4cd191b2c10b4a87b1e9681afc34fb138c705f91f7330ff90bfa36f457e5584076a2b8
+  checksum: ad59734723b596d0891321c951592ed9015a77ce84907f89c9d9307dd0c06e11a67906a3e628c4cae143d3e44898603478af0ddeb2bba3f229a9373efe342665
   languageName: node
   linkType: hard
 
@@ -18421,8 +18421,8 @@ react@latest:
   linkType: hard
 
 "sharp@npm:^0.32.1":
-  version: 0.32.2
-  resolution: "sharp@npm:0.32.2"
+  version: 0.32.3
+  resolution: "sharp@npm:0.32.3"
   dependencies:
     color: ^4.2.3
     detect-libc: ^2.0.1
@@ -18433,7 +18433,7 @@ react@latest:
     simple-get: ^4.0.1
     tar-fs: ^3.0.4
     tunnel-agent: ^0.6.0
-  checksum: 2d6b9bcada4c4cc6f606003213d866f975254da011a30972d422086e69ae280973dbedbdb91aa636d98de874fd0eb7af42f0aaff044c22e7e65da28e25c7d63a
+  checksum: 8a6ed0d00bd4d3d6ba92c392fe1f00a4a207f138257a4d903ce5afe5c6d7f684b5218c5b4e8df1097aac960ac10e0114c823f6a8a7e18255bf4a8ec364087051
   languageName: node
   linkType: hard
 
@@ -21149,28 +21149,28 @@ react@latest:
   languageName: node
   linkType: hard
 
-"workbox-background-sync@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-background-sync@npm:6.6.1"
+"workbox-background-sync@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-background-sync@npm:6.6.0"
   dependencies:
     idb: ^7.0.1
-    workbox-core: 6.6.1
-  checksum: cc05e68c075c58020fe435506df5c555a83ebd9b4cdbe5f38f40783112c7e6218be82354077af8b80c311946a824590fe24ee11bbd3b95008ec209b456212c20
+    workbox-core: 6.6.0
+  checksum: ac2990110643aef62ca0be54e962296de7b09593b0262bd09fe4893978a42fa1f256c6d989ed472a31ae500b2255b80c6678530a6024eafb0b2f3a93a3c94a5f
   languageName: node
   linkType: hard
 
-"workbox-broadcast-update@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-broadcast-update@npm:6.6.1"
+"workbox-broadcast-update@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-broadcast-update@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-  checksum: 4cc88f5e2e94beed805e128da62f77ef6da77c84a687cce1639252884c8a2d1453179cc5b719fc8c1458dd15da6dccc8f335580db398619cfda56cc520b3b4ff
+    workbox-core: 6.6.0
+  checksum: 46a74b3b703244eb363e1731a2d6fe1fb2cd9b82d454733dfc6941fd35b76a852685f56db92408383ac50d564c2fd4282f0c6c4db60ba9beb5f311ea8f944dc7
   languageName: node
   linkType: hard
 
-"workbox-build@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-build@npm:6.6.1"
+"workbox-build@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-build@npm:6.6.0"
   dependencies:
     "@apideck/better-ajv-errors": ^0.3.1
     "@babel/core": ^7.11.1
@@ -21194,163 +21194,163 @@ react@latest:
     strip-comments: ^2.0.1
     tempy: ^0.6.0
     upath: ^1.2.0
-    workbox-background-sync: 6.6.1
-    workbox-broadcast-update: 6.6.1
-    workbox-cacheable-response: 6.6.1
-    workbox-core: 6.6.1
-    workbox-expiration: 6.6.1
-    workbox-google-analytics: 6.6.1
-    workbox-navigation-preload: 6.6.1
-    workbox-precaching: 6.6.1
-    workbox-range-requests: 6.6.1
-    workbox-recipes: 6.6.1
-    workbox-routing: 6.6.1
-    workbox-strategies: 6.6.1
-    workbox-streams: 6.6.1
-    workbox-sw: 6.6.1
-    workbox-window: 6.6.1
-  checksum: 858d88a0aa9e0a8aec5f528b305e3fa7db3778f762d1866fe69c16a11016d0ab8675625ad967660edf8e262ff62dd599c30ac8b5a0618f6974e89ed1d2b41a38
+    workbox-background-sync: 6.6.0
+    workbox-broadcast-update: 6.6.0
+    workbox-cacheable-response: 6.6.0
+    workbox-core: 6.6.0
+    workbox-expiration: 6.6.0
+    workbox-google-analytics: 6.6.0
+    workbox-navigation-preload: 6.6.0
+    workbox-precaching: 6.6.0
+    workbox-range-requests: 6.6.0
+    workbox-recipes: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+    workbox-streams: 6.6.0
+    workbox-sw: 6.6.0
+    workbox-window: 6.6.0
+  checksum: cd1a6c413659c2fd66f4438012f65b211cc748bb594c79bf0d9a60de0cefff3f8a4a23ab06f32c62064c37397ffffc1b77d3328658b7556ea7ff88e57f6ee4fd
   languageName: node
   linkType: hard
 
-"workbox-cacheable-response@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-cacheable-response@npm:6.6.1"
+"workbox-cacheable-response@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-cacheable-response@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-  checksum: 5095404f11b44d97fdec1bedf6a59dd4e6967c9bbd5d13ff7a93433208b4c63062c72f8fcfe358bc310c14fe4dd062f11c1d07cdd88cf050fcfab9c303b7e8cc
+    workbox-core: 6.6.0
+  checksum: 9e4e00c53679fd2020874cbdf54bb17560fd12353120ea08ca6213e5a11bf08139072616d79f5f8ab80d09f00efde94b003fe9bf5b6e23815be30d7aca760835
   languageName: node
   linkType: hard
 
-"workbox-core@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-core@npm:6.6.1"
-  checksum: b11f3908607328e3886878aafb326f1d62052e3adf778f65ae9f80dc10a002e84e1c70e9c32d852bd4961fd1e42dd42cbf4617de6bb4692f941abab458780baf
+"workbox-core@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-core@npm:6.6.0"
+  checksum: 7d773a866b73a733780c52b895f9cf7bec926c9187395c307174deefba9a0a2fcd1edce0d1ca12b8a6c95ca9cf7755ccc1885b03bc82ebcfc4843e015bd84d7b
   languageName: node
   linkType: hard
 
-"workbox-expiration@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-expiration@npm:6.6.1"
+"workbox-expiration@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-expiration@npm:6.6.0"
   dependencies:
     idb: ^7.0.1
-    workbox-core: 6.6.1
-  checksum: ae1425b9554345900a2a391b221434fcfe8976cf746c11116f4e72427c5e3b2e49f63276505de08017fec93169101241d57b0a9bca7cc39e48db25bbc289dfb8
+    workbox-core: 6.6.0
+  checksum: b100b9c512754bc3e1a9c7c7d20d215d72c601a7b956333ca7753704a771a9f00e1732e9b774da4549bae390dd3cd138c6392f6a25fd67f7dcd84f89b0df7e9c
   languageName: node
   linkType: hard
 
-"workbox-google-analytics@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-google-analytics@npm:6.6.1"
+"workbox-google-analytics@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-google-analytics@npm:6.6.0"
   dependencies:
-    workbox-background-sync: 6.6.1
-    workbox-core: 6.6.1
-    workbox-routing: 6.6.1
-    workbox-strategies: 6.6.1
-  checksum: 85f2b783ba95241e241f29a239bd42ee099f318e74517e89c9f66961b2ac0ec57fa7840112df38cb8c46c18531a715edb3ca306f58afb8f285abb8e984ae3e33
+    workbox-background-sync: 6.6.0
+    workbox-core: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+  checksum: 7b287da7517ae416aae8ea1494830bb517a29ab9786b2a8b8bf98971377b83715070e784399065ab101d4bba381ab0abbb8bd0962b3010bc01f54fdafb0b6702
   languageName: node
   linkType: hard
 
-"workbox-navigation-preload@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-navigation-preload@npm:6.6.1"
+"workbox-navigation-preload@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-navigation-preload@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-  checksum: 2b3e2a7aa127f9b5934a430b5bc9ab1871238c7a4488aa86592fe796869dac4dd9a192d1c16be2d09e176a046f7b851d5fc9e46a938eb5e4523b58f6a41e50bf
+    workbox-core: 6.6.0
+  checksum: d254465648e45ec6b6d7c3471354336501901d3872622ea9ba1aa1f935d4d52941d0f92fa6c06e7363e10dbac4874d5d4bff7d99cbe094925046f562a37e88cc
   languageName: node
   linkType: hard
 
-"workbox-precaching@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-precaching@npm:6.6.1"
+"workbox-precaching@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-precaching@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-    workbox-routing: 6.6.1
-    workbox-strategies: 6.6.1
-  checksum: 48d1926f2c82c28d860076c23db19ad2f863c430261ca6287e134e9f88a6bdabb8ed97734d2893cc1136fb4d35c342b842e5745407f34a2e6176e352e4b1a2df
+    workbox-core: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+  checksum: 62e5ee2e40568a56d4131bba461623579f56b9bd273aa7d2805e43151057f413c2ef32fb3d007aff0a5ac3ad84d5feae87408284249a487a5d51c3775c46c816
   languageName: node
   linkType: hard
 
-"workbox-range-requests@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-range-requests@npm:6.6.1"
+"workbox-range-requests@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-range-requests@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-  checksum: 0002496256bdc86749f39723f6428e98855f8725a4c3d1cfe0526994383ac6d18ddbfc662109214fa7648cd3d63c2183dced6732d25493e4037c4145fa181ada
+    workbox-core: 6.6.0
+  checksum: a55d1a364b2155548695dc8f6f85baade196d7d1bec980bcdbda80236803b14167995a81b944cffe932a94c4d556466773121afe3661a6f0a13403cbe96d8d9f
   languageName: node
   linkType: hard
 
-"workbox-recipes@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-recipes@npm:6.6.1"
+"workbox-recipes@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-recipes@npm:6.6.0"
   dependencies:
-    workbox-cacheable-response: 6.6.1
-    workbox-core: 6.6.1
-    workbox-expiration: 6.6.1
-    workbox-precaching: 6.6.1
-    workbox-routing: 6.6.1
-    workbox-strategies: 6.6.1
-  checksum: 2ed3dc06798ee31a8c8930b8656224aac0a1513d6476b432155e9aedca6c946fe4b034f358364886c733398ecb776f42fd5806d52ab83d406a456d03b6af5a15
+    workbox-cacheable-response: 6.6.0
+    workbox-core: 6.6.0
+    workbox-expiration: 6.6.0
+    workbox-precaching: 6.6.0
+    workbox-routing: 6.6.0
+    workbox-strategies: 6.6.0
+  checksum: f2ecf38502260703e4b0dcef67e3ac26d615f2c90f6d863ca7308db52454f67934ba842fd577ee807d9f510f1a277fd66af7caf57d39e50a181d05dbb3e550a7
   languageName: node
   linkType: hard
 
-"workbox-routing@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-routing@npm:6.6.1"
+"workbox-routing@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-routing@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-  checksum: fc9763ebddadf1b4edaa8ae327c382b98f356d5212315cd7c902e2b863f7fa28b439bcfa56d9cdfaf573a357b0852adfb4821c11635bf68cdd34795104d5c60e
+    workbox-core: 6.6.0
+  checksum: 7a70b836196eb67332d33a94c0b57859781fe869e81a9c95452d3f4f368d3199f8c3da632dbc10425fde902a1930cf8cfd83f6434ad2b586904ce68cd9f35c6d
   languageName: node
   linkType: hard
 
-"workbox-strategies@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-strategies@npm:6.6.1"
+"workbox-strategies@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-strategies@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-  checksum: e0382eac3062b243e0e422ee2b09dc3105158d4280893d351c69b7cf737c935e3028e3bf4cd35ecefa996fbc7813f1bd222dc0b48caa99394743189d30d4dabb
+    workbox-core: 6.6.0
+  checksum: 236232a77fb4a4847d1e9ae6c7c9bd9c6b9449209baab9d8d90f78240326a9c0f69551b408ebf9e76610d86da15563bf27439b7e885a7bac01dfd08047c0dd7b
   languageName: node
   linkType: hard
 
-"workbox-streams@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-streams@npm:6.6.1"
+"workbox-streams@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-streams@npm:6.6.0"
   dependencies:
-    workbox-core: 6.6.1
-    workbox-routing: 6.6.1
-  checksum: dffab50f95380db3cf48496db1d42df25ec1c6054da2a6176479290b0fd6ba3e0acedb1f946ee0425a8009a79cbcddc691a9bf3d710b62bc0e676db4306d7c46
+    workbox-core: 6.6.0
+    workbox-routing: 6.6.0
+  checksum: 64a295e48e44e3fa4743b5baec646fc9117428e7592033475e38c461e45c294910712f322c32417d354b22999902ef8035119e070e61e159e531d878d991fc33
   languageName: node
   linkType: hard
 
-"workbox-sw@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-sw@npm:6.6.1"
-  checksum: 8a9eeae4531ceb5cbdaf6c6ed3dc5039a67f20a644c5ff1869fc3a219a8155a4dfc4acb783b0dce0a9bb42090bf7b9618e21d6deb2483c8eb168e5c15ae9ade7
+"workbox-sw@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-sw@npm:6.6.0"
+  checksum: bb5f8695de02f89c7955465dcbd568299915565008dc8a068c5d19c1347f75d417640b9f61590e16b169b703e77d02f8b1e10c4b241f74f43cfe76175bfa5fed
   languageName: node
   linkType: hard
 
 "workbox-webpack-plugin@npm:^6.4.1":
-  version: 6.6.1
-  resolution: "workbox-webpack-plugin@npm:6.6.1"
+  version: 6.6.0
+  resolution: "workbox-webpack-plugin@npm:6.6.0"
   dependencies:
     fast-json-stable-stringify: ^2.1.0
     pretty-bytes: ^5.4.1
     upath: ^1.2.0
     webpack-sources: ^1.4.3
-    workbox-build: 6.6.1
+    workbox-build: 6.6.0
   peerDependencies:
     webpack: ^4.4.0 || ^5.9.0
-  checksum: 91d379f63202a0daae51b9f27db18b6d27c3184bb553925143002ada79e28735be22b339ce88cbe804d451345d5840fa21a362915c092e1eb036507630cdb8f1
+  checksum: b8e04a342f2d45086f28ae56e4806d74dd153c3b750855533a55954f4e85752113e76a6d79a32206eb697a342725897834c9e7976894374d8698cd950477d37a
   languageName: node
   linkType: hard
 
-"workbox-window@npm:6.6.1":
-  version: 6.6.1
-  resolution: "workbox-window@npm:6.6.1"
+"workbox-window@npm:6.6.0":
+  version: 6.6.0
+  resolution: "workbox-window@npm:6.6.0"
   dependencies:
     "@types/trusted-types": ^2.0.2
-    workbox-core: 6.6.1
-  checksum: 24f193ce44c214bbddea3eec9a937b97d3edf706f20bb47a3699babcf0d172a8be97cd3d97b9d6838bbca711c35530cd82bd8be23e6546bbb58e708c13d33167
+    workbox-core: 6.6.0
+  checksum: bb1dd031c1525317ceffbdc3e4f502a70dce461fd6355146e1050c1090f3c640bf65edf42a5d2a3b91b4d0c313df32c1405d88bf701d44c0e3ebc492cd77fe14
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
navigation sync is usable
- verse highlight is now disabled, due to that the changes in the perf structure caused unwanted undo history events
- suppressing sync actions in originating editing window (although not 100% successful, due to below issue)
- attempt to only use inner (nearest) scrollbar for sync - this is not 100% successful due to how the browsers have implemented this, but it now seems at least usable