### PR TITLE
Enable font control for Print and for onscreen Display

### DIFF
--- a/packages/base/src/renderer/renderStyles.js
+++ b/packages/base/src/renderer/renderStyles.js
@@ -1,7 +1,6 @@
 const renderStyles = {
   paras: {
     default: {
-      fontSize: 'medium',
       marginTop: '0.5ex',
       marginBottom: '0.5ex',
     },

--- a/packages/base/src/renderer/renderStylesRtl.js
+++ b/packages/base/src/renderer/renderStylesRtl.js
@@ -3,7 +3,6 @@ const renderStyles = {
   paras: {
     default: {
       direction: 'rtl',
-      fontSize: 'medium',
       marginTop: '0.5ex',
       marginBottom: '0.5ex',
     },

--- a/packages/mui-core/src/components/Editor.jsx
+++ b/packages/mui-core/src/components/Editor.jsx
@@ -149,8 +149,6 @@ const EditorContainer = styled(Box)`
   p.p {
     margin: 0;
     padding: 1em 0.5em;
-    line-height: 1.4;
-    font-family: sans-serif;
   }
   span.mark:is(.verses, .chapter) {
     display: inline-block;

--- a/packages/mui-core/src/components/Editor.md
+++ b/packages/mui-core/src/components/Editor.md
@@ -2,9 +2,9 @@
 
 #### Other packages in the same monorepo: 
 
-pk - https://oce-editor-tools-pk.netlify.app
+pk - https://oce-editor-tools-mui-pk.netlify.app/
 
-simple - https://simple-oce-editor-tools.netlify.app
+simple - https://oce-editor-tools-mui-simple.netlify.app/
 
 ## Editor demo 1
 
@@ -73,7 +73,17 @@ function MyEditor({
     ...props,
   };
 
-  return <>{ready ? <Editor {...editorProps} /> : "Loading..."}</>;
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
+  return (
+    <>
+      <div style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
+        {ready ? <Editor {...editorProps} /> : "Loading..."}
+      </div>
+    </>
+  )
 }
 
 function GridCard({ title, children }) {
@@ -205,9 +215,13 @@ function Component () {
     verbose
   }
  
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
   return (
     <>
-    <div key="1">
+    <div key="1" style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
       { ready ? <Editor key="1" {...editorProps} /> : 'Loading...' }
     </div>
     </>
@@ -324,10 +338,14 @@ function Component () {
     onRenderToolbar,
     verbose
   }
+
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
   
   return (
     <>
-    <div key="1">
+    <div key="1" style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
       { ready ? <Editor key="1" {...editorProps} /> : 'Loading...'}
     </div>
     </>

--- a/packages/mui-core/src/components/PrintDrawer.jsx
+++ b/packages/mui-core/src/components/PrintDrawer.jsx
@@ -36,6 +36,9 @@ export default function PrintDrawer({
   onRenderContent,
   canChangeAtts,
   canChangeColumns,
+  printFont,
+  printFontSize,
+  printLineHeight,
 }) {
 
   const allNames = [
@@ -101,7 +104,8 @@ export default function PrintDrawer({
   const onPrintClick = () => {
     const renderedData = onRenderContent && onRenderContent()
     const newPage = window.open()
-    newPage.document.body.innerHTML = `<div id="paras">${renderedData}</div>`
+    newPage.document.body.innerHTML = `<div id="paras" style="
+    font-family: ${printFont}; font-size: ${printFontSize}; line-height: ${printLineHeight};">${renderedData}</div>`
     // ToDo: LG - Find another way of triggering the print action
     // This onLoad triggers too early in Chrome and doesn't work in Firefox
     // newPage.document.body.setAttribute('onLoad',"window.print()");
@@ -206,7 +210,13 @@ PrintDrawer.propTypes = {
   /** needs to return the content that needs to be rendered */
   onRenderContent: PropTypes.func,
   canChangeAtts: PropTypes.bool,
-  canChangeColumns: PropTypes.bool
+  canChangeColumns: PropTypes.bool,
+  /** Print font */
+  printFont: PropTypes.string,
+  /** Print font size */
+  printFontSize: PropTypes.string,
+  /** Print line height */
+  printLineHeight: PropTypes.string,
 }
 
 PrintDrawer.defaultProps = {

--- a/packages/mui-core/src/components/PrintDrawer.md
+++ b/packages/mui-core/src/components/PrintDrawer.md
@@ -45,6 +45,10 @@ function Component () {
     renderStyles,
   })
 
+  const displayFont = 'sans-serif';
+  const displayFontSize = '100%';
+  const displayLineHeight = '1.13';
+
   const previewProps = {
     openPrintDrawer: isOpen && ready,
     onClosePrintDrawer: () => {
@@ -54,10 +58,13 @@ function Component () {
     onRenderContent: () => renderedData,
     canChangeAtts: false,
     canChangeColumns: true,
+    printFont: displayFont,
+    printFontSize: displayFontSize,
+    printLineHeight: displayLineHeight,
   }
-  
+
   return (
-      <div key="1">
+      <div key="1" style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
         { ready && (<button onClick={handleClick}>
           Print preview
         </button>)}
@@ -160,8 +167,12 @@ function Component () {
     onRenderContent: () => markup(markupStr),
   }
   
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
   return (
-    <div>
+    <div style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
       <button onClick={handleClick}>
         Print preview
       </button>

--- a/packages/mui-pk/src/components/PkEditor.md
+++ b/packages/mui-pk/src/components/PkEditor.md
@@ -2,9 +2,9 @@
 
 ## Other packages in the same monorepo
 
-core - https://oce-editor-tools-pk.netlify.app
+core - https://oce-editor-tools-mui-core.netlify.app/
 
-simple - https://simple-oce-editor-tools.netlify.app
+simple - https://oce-editor-tools-mui-simple.netlify.app/
 
 ## PkEditor demo
 
@@ -54,7 +54,17 @@ function MyEditor({
     ...props,
   }
 
-  return <>{done ? <PkEditor {...editorProps} /> : "Loading..."}</>
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
+  return (
+    <>
+      <div style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
+        {done ? <PkEditor {...editorProps} /> : "Loading..."}
+      </div>
+    </>
+  )
 }
 
 function GridCard({ title, children }) {
@@ -249,8 +259,12 @@ function Component () {
     verbose: true,
   }
   
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
   return (
-      <div key="1">
+      <div key="1" style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
         { done ? <PkEditor {...editorProps} /> : 'Loading...'}
       </div>
   )

--- a/packages/mui-pk/src/components/PkPreview.jsx
+++ b/packages/mui-pk/src/components/PkPreview.jsx
@@ -9,7 +9,7 @@ import {
 
 export default function PkPreview(props) {
   const {
-    repoIdStr, langIdStr, bookId, verbose, extInfo, renderFlags,
+    repoIdStr, langIdStr, bookId, verbose, extInfo, renderFlags, pkFont,
   } = props;
 
   const [docIdFromCache, setDocIdFromCache] = useState(undefined)
@@ -27,7 +27,7 @@ export default function PkPreview(props) {
     bookId,
     renderFlags,
     extInfo, 
-    verbose
+    verbose,
   })
 
   useEffect(() => {
@@ -51,7 +51,7 @@ export default function PkPreview(props) {
 
 
   return (
-    <Grid container style={{ fontFamily: 'Arial' }}>
+    <Grid container style={{ fontFamily: pkFont }}>
       <Grid key={2} item xs={12}>
         {(done && renderedData) ? <>{renderedData}</> : <Typography>{'LOADING'}...</Typography>}
       </Grid>
@@ -72,8 +72,11 @@ PkPreview.propTypes = {
   extInfo: PropTypes.any,
   /** Whether to show extra info in the js console */
   verbose: PropTypes.bool,
+  /** PK Display font */
+  pkFont: PropTypes.string,
 };
 
 PkPreview.defaultProps = {
   verbose: false,
+  pkFont: 'Arial',
 };

--- a/packages/mui-pk/src/components/PkPreview.md
+++ b/packages/mui-pk/src/components/PkPreview.md
@@ -23,16 +23,22 @@ function Component () {
     showVersesLabels: true,
   };
 
+  const displayFont = 'sans-serif';
+
   const previewProps = {
     repoIdStr,
     langIdStr,
     bookId,
     renderFlags,
     verbose: true,
+    pkFont: displayFont,
   }
   
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
   return (
-      <div key="1">
+      <div key="1" style={{ fontSize: displayFontSize, lineHeight: displayLineHeight }}>
         { done ? <PkPreview {...previewProps} /> : 'Loading...'}
       </div>
   );
@@ -136,6 +142,7 @@ const renderFlags = {
     showVersesLabels: true,
   };
 
+  const displayFont = 'sans-serif';
 
   const previewProps = {
     repoIdStr,
@@ -144,10 +151,14 @@ const renderFlags = {
     renderFlags,
     extInfo,
     verbose: true,
+    pkFont: displayFont,
   }
-  
+
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
   return (
-      <div key="1">
+      <div key="1" style={{ fontSize: displayFontSize, lineHeight: displayLineHeight }}>
         { done ? <PkPreview {...previewProps} /> : 'Loading...'}
       </div>
   );

--- a/packages/mui-pk/src/components/PkPrintDrawer.jsx
+++ b/packages/mui-pk/src/components/PkPrintDrawer.jsx
@@ -25,6 +25,9 @@ export default function PkPrintDrawer({
   verbose, 
   extInfo, 
   renderFlags: _renderFlags,
+  printFont,
+  printFontSize,
+  printLineHeight,
 }) {
 
   const allNames = [
@@ -94,6 +97,9 @@ export default function PkPrintDrawer({
     openPrintDrawer,
     onClosePrintDrawer,
     onRenderContent: handleRender,
+    printFont,
+    printFontSize,
+    printLineHeight
   }
 
   return (
@@ -118,6 +124,12 @@ PkPrintDrawer.propTypes = {
   extInfo: PropTypes.any,
   /** Whether to show extra info in the js console */
   verbose: PropTypes.bool,
+  /** Print font */
+  printFont: PropTypes.string,
+  /** Print font size */
+  printFontSize: PropTypes.string,
+  /** Print line height */
+  printLineHeight: PropTypes.string,
 };
 
 PkPrintDrawer.defaultProps = {

--- a/packages/mui-pk/src/components/PkPrintDrawer.md
+++ b/packages/mui-pk/src/components/PkPrintDrawer.md
@@ -30,6 +30,10 @@ function Component () {
     setIsOpen(!isOpen)
   }
 
+  const displayFont = 'sans-serif';
+  const displayFontSize = '100%';
+  const displayLineHeight = '1.13';
+
   const previewProps = {
     openPrintDrawer: isOpen && done,
     onClosePrintDrawer: () => {
@@ -41,6 +45,9 @@ function Component () {
     bookId,
     renderFlags,
     verbose: true,
+    printFont: displayFont,
+    printFontSize: displayFontSize,
+    printLineHeight: displayLineHeight,
   }
   
   return (

--- a/packages/mui-pk/src/components/PkUsfmEditor.md
+++ b/packages/mui-pk/src/components/PkUsfmEditor.md
@@ -53,7 +53,15 @@ function MyEditor({
     ...props,
   }
 
-  return <PkUsfmEditor {...editorProps} />
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
+  return (
+      <div style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
+        <PkUsfmEditor {...editorProps} />
+      </div>
+  );
 }
 
 function GridCard({ title, children }) {

--- a/packages/mui-simple/src/components/UsfmEditor.md
+++ b/packages/mui-simple/src/components/UsfmEditor.md
@@ -1,10 +1,9 @@
 ## Package: Simple
 #### Other packages in the same monorepo: 
 
-core - https://oce-editor-tools-pk.netlify.app
+core - https://oce-editor-tools-mui-core.netlify.app/
 
-pk - https://oce-editor-tools-pk.netlify.app
-
+pk - https://oce-editor-tools-mui-pk.netlify.app/
 
 # UsfmEditor demo
 
@@ -34,9 +33,13 @@ function Component () {
       verse: "24-25",
     }
   }
-  
+
+  const displayFont = 'sans-serif';
+  const displayFontSize = 'medium';
+  const displayLineHeight = '1.4';
+
   return (
-    <div key="1">
+    <div key="1" style={{ fontFamily: displayFont, fontSize: displayFontSize, lineHeight: displayLineHeight }}>
       <UsfmEditor {...editorProps} />
     </div>
   );


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Added PrintDrawer and PkPrintDrawer props for font, font size and line height
- Added a PkPreview font prop with a default in place of hard-coding in the returned grid container
- Removed font size from renderStyles so this can be controlled elsewhere
- Removed font family and line height from EditorContainer so these can be controlled elsewhere
- Added font control examples to all styleguide playground areas
- Fixed links pointing from each styleguide to the other two styleguides

#### Please include detailed Test instructions for your pull request:
- Explore altering all font setting examples that are now present in each styleguide example (tested locally for each)

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [x] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
